### PR TITLE
Add timeout option

### DIFF
--- a/cypress/e2e/click.cy.js
+++ b/cypress/e2e/click.cy.js
@@ -49,6 +49,13 @@ it('uses hasEventListeners command', () => {
   cy.get('button#one').click()
 })
 
+it('uses hasEventListeners command with timeout option', () => {
+  cy.visit('public/index.html')
+  cy.hasEventListeners('button#two', { timeout: 10000 })
+  // now we can click that button
+  cy.get('button#two').click()
+})
+
 it('handles selectors with quotes', () => {
   cy.visit('public/index.html')
   const selector = '[aria-label="Click this button"]'
@@ -59,7 +66,7 @@ it('handles selectors with quotes', () => {
 
 it('handles jQuery selectors', () => {
   cy.visit('public/index.html')
-  const selector = 'button:contains("Click me")'
+  const selector = 'button:contains("Click me!")'
   cy.hasEventListeners(selector)
   // now we can click that button
   cy.get(selector).click()

--- a/public/app.js
+++ b/public/app.js
@@ -1,9 +1,18 @@
-const btn = document.querySelector('#one')
-const output = document.querySelector('#output')
+const btn_one = document.querySelector('#one')
+const btn_two = document.querySelector('#two')
+const output_one = document.querySelector('#output')
+const output_two = document.querySelector('#output-two')
 
 // add event listeners after a short delay
 setTimeout(() => {
-  btn.addEventListener('click', () => {
+  btn_one.addEventListener('click', () => {
     output.innerText = 'clicked'
   })
 }, 1000)
+
+// add event listeners after a long delay
+setTimeout(() => {
+  btn_two.addEventListener('click', () => {
+    output_two.innerText = 'clicked'
+  })
+}, 5000)

--- a/public/index.html
+++ b/public/index.html
@@ -8,8 +8,16 @@
   </head>
   <body>
     <p>This is the text</p>
-    <button id="one" aria-label="Click this button">Click me</button>
-    <output id="output"></output>
+    <div>
+      <button id="one" aria-label="Click this button">Click me!</button>
+      <output id="output"></output>
+    </div>
+    <div>
+      <button id="two" aria-label="Click this button with extra patience">
+        Click me too!
+      </button>
+      <output id="output-two"></output>
+    </div>
     <script src="app.js"></script>
   </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,3 +1,6 @@
 body {
   font-family: 'Satisfy', cursive;
+  div:not(:last-child) {
+    margin-bottom: 1rem;
+  }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -40,8 +40,9 @@ declare global {
 
       //#region hasEventListeners
       interface hasEventListenersFnOptions {
-        log: LogConfig
-        type: string
+        log?: LogConfig
+        timeout?: number
+        type?: string
       }
       type hasEventListenersFn = (
         selector: string,

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,10 @@ Cypress.Commands.add('hasEventListeners', (selector, options = {}) => {
           depth: -1,
           pierce: true,
         },
-        { log: false },
+        {
+          log: false,
+          timeout: options.timeout,
+        },
       )
         .should((v) => {
           if (!v.listeners) {


### PR DESCRIPTION
Added an additional parameter option `timeout`, which is useful for CPU-limited test executions (headless CPU-rendered CI runs, for example) where the JS may take longer than the default 4 seconds to attach event listeners. Also added a test to confirm it works.