### PR TITLE
fix: support flexible log options for CDP commands

### DIFF
--- a/cypress/e2e/cdp-log.cy.js
+++ b/cypress/e2e/cdp-log.cy.js
@@ -1,0 +1,82 @@
+/// <reference types="cypress" />
+// @ts-check
+
+import '../../src'
+
+/** @type {Array<(attributes: {name?: string}) => void>} */
+const logAddedHandlers = []
+
+/** @param {(attributes: {name?: string}) => void} handler */
+const addLogAddedHandler = (handler) => {
+  logAddedHandlers.push(handler)
+  Cypress.on('log:added', handler)
+}
+
+afterEach(() => {
+  for (const handler of logAddedHandlers.splice(0)) {
+    Cypress.off('log:added', handler)
+  }
+})
+
+it('should not create a Cypress log entry when logging is disabled', () => {
+  let cdpLogCount = 0
+  /** @param {{ name?: string }} attributes */
+  const onLogAdded = (attributes) => {
+    if (attributes.name === 'CDP') {
+      cdpLogCount += 1
+    }
+  }
+
+  addLogAddedHandler(onLogAdded)
+
+  cy.CDP(
+    'Runtime.evaluate',
+    { expression: 'document.readyState' },
+    { log: false },
+  )
+
+  cy.then(() => {
+    cy.wrap(cdpLogCount).should('eq', 0)
+  })
+})
+
+it('should create a Cypress log entry when logging is enabled', () => {
+  let cdpLogCount = 0
+  /** @param {{ name?: string }} attributes */
+  const onLogAdded = (attributes) => {
+    if (attributes.name === 'CDP') {
+      cdpLogCount += 1
+    }
+  }
+
+  addLogAddedHandler(onLogAdded)
+
+  cy.CDP('Runtime.evaluate', { expression: 'document.readyState' })
+
+  cy.then(() => {
+    cy.wrap(cdpLogCount).should('eq', 1)
+  })
+})
+
+it('should merge custom Cypress log options into the CDP log entry', () => {
+  /** @type {{ displayName?: string } | undefined} */
+  let cdpLogAttributes
+  /** @param {{ name?: string, displayName?: string }} attributes */
+  const onLogAdded = (attributes) => {
+    if (attributes.name === 'CDP') {
+      cdpLogAttributes = attributes
+    }
+  }
+
+  addLogAddedHandler(onLogAdded)
+
+  cy.CDP(
+    'Runtime.evaluate',
+    { expression: 'document.readyState' },
+    { log: { displayName: 'Custom CDP' } },
+  )
+
+  cy.then(() => {
+    cy.wrap(cdpLogAttributes?.displayName).should('eq', 'Custom CDP')
+  })
+})

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,8 +24,10 @@ declare global {
           : RdpCommands[RdpCommandName]['paramsType'][number]
       type CdpCommandFnReturnType<RdpCommandName extends RdpCommandNames> =
         RdpCommands[RdpCommandName]['returnType']
+      type CommandLogOption = boolean | Partial<LogConfig>
       interface CdpCommandFnOptions {
-        log: LogConfig
+        log?: CommandLogOption
+        timeout?: number
       }
       type CdpCommandFn = <RdpCommandName extends RdpCommandNames>(
         rdpCommand: RdpCommandName,
@@ -40,7 +42,7 @@ declare global {
 
       //#region hasEventListeners
       interface hasEventListenersFnOptions {
-        log?: LogConfig
+        log?: CommandLogOption
         timeout?: number
         type?: string
       }

--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,28 @@
 /// <reference types="cypress" />
 
-Cypress.Commands.add('CDP', (rdpCommand, params, options = {}) => {
-  const logOptions = {
-    name: 'CDP',
-    message: rdpCommand,
-  }
-
+const formatMessage = (rdpCommand, params) => {
   if (rdpCommand === 'DOM.querySelector') {
-    logOptions.message += ' ' + params.selector
-  } else {
-    const limitN = 60
-    const paramsStringified = params ? JSON.stringify(params) : ''
-    logOptions.message +=
-      paramsStringified.length > limitN
-        ? ' ' + paramsStringified.slice(0, limitN) + '...'
-        : ' ' + paramsStringified
+    return `${rdpCommand} ${params?.selector ?? ''}`
   }
 
-  let log
-  if (options.log !== false) {
-    log = Cypress.log(logOptions)
-  }
+  const limit = 60
+  const paramsStringified = params ? JSON.stringify(params) : ''
+
+  return paramsStringified.length > limit
+    ? `${rdpCommand} ${paramsStringified.slice(0, limit)}...`
+    : `${rdpCommand} ${paramsStringified}`
+}
+
+Cypress.Commands.add('CDP', (rdpCommand, params, options = {}) => {
+  const shouldLog = options.log !== false
+  const customLogOptions = typeof options.log === 'object' ? options.log : {}
+  const log = shouldLog
+    ? Cypress.log({
+        name: 'CDP',
+        message: formatMessage(rdpCommand, params),
+        ...customLogOptions,
+      })
+    : undefined
 
   const getValue = () => {
     return Cypress.automation('remote:debugger:protocol', {
@@ -38,12 +40,13 @@ Cypress.Commands.add('CDP', (rdpCommand, params, options = {}) => {
   }
 
   return resolveValue().then((value) => {
-    if (options.log !== false) {
-      logOptions.consoleProps = () => {
-        return {
+    if (log) {
+      log.set({
+        consoleProps: () => ({
           result: value,
-        }
-      }
+        }),
+      })
+
       log.snapshot().end()
     }
 
@@ -72,18 +75,18 @@ Cypress.Commands.add('hasEventListeners', (selector, options = {}) => {
       }
     }, maxTimeout)
   }
-  const logOptions = {
-    name: 'hasEventListeners',
-    message: `checking element "${selector}"`,
-  }
-  let log
-  if (options.log !== false) {
-    log = Cypress.log(logOptions)
-  }
+
+  const shouldLog = options.log !== false
+  const log = shouldLog
+    ? Cypress.log({
+        name: 'hasEventListeners',
+        message: `checking element "${selector}"`,
+      })
+    : undefined
 
   cy.get(selector, { log: false, timeout: maxTimeout }).should(($el) => {
     if ($el.length !== 1) {
-      throw new Error(`Need a single element with selector "${selector}`)
+      throw new Error(`Need a single element with selector "${selector}"`)
     }
   })
 
@@ -132,12 +135,15 @@ Cypress.Commands.add('hasEventListeners', (selector, options = {}) => {
           }
         }
         eventListenerStatus = 'Passed'
-        if (options.log !== false) {
-          logOptions.consoleProps = () => {
-            return {
+
+        if (log) {
+          log.set({
+            consoleProps: () => ({
               result: v.listeners,
-            }
-          }
+            }),
+          })
+
+          log.snapshot().end()
         }
       })
     })


### PR DESCRIPTION
Changes:

- Updated `log` to accept `boolean` values.
- Refactored the logging logic to support disabled logging and custom log configs while being consistent with the Cypress docs.
- Added test coverage for disabled logging and custom log configs.
- Fixed a typo in the `hasEventListeners` error message.

Closes https://github.com/bahmutov/cypress-cdp/issues/99
