### PR TITLE
feat: support log suppression in getCDPNodeId

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ cy.getCDPNodeId('body').then((nodeId) => {
 })
 ```
 
+Pass `{ log: false }` to suppress the internal `CDP` command log entries.
+
+```js
+cy.getCDPNodeId('body', { log: false }).then((nodeId) => {
+  cy.CDP('CSS.getPlatformFontsForNode', {
+    nodeId,
+  })
+})
+```
+
 ## Type definitions
 
 Defined in [src/index.d.ts](./src/index.d.ts) and copied from the original [PR 66237](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66237). If you want your project to "know" the `cy.CDP` command, include this dependency, for example:

--- a/cypress/e2e/get-cdp-node-id.cy.js
+++ b/cypress/e2e/get-cdp-node-id.cy.js
@@ -1,0 +1,81 @@
+/// <reference types="cypress" />
+// @ts-check
+
+import '../../src'
+
+/**
+ * @template T
+ * @param {() => Cypress.Chainable<T>} runCommand
+ */
+const collectCdpMessages = (runCommand) => {
+  /** @type {string[]} */
+  const messages = []
+
+  /**
+   * @param {{ name?: string, message?: string }} attrs
+   */
+  const onLogAdded = (attrs) => {
+    if (attrs.name === 'CDP' && typeof attrs.message === 'string') {
+      messages.push(attrs.message)
+    }
+  }
+
+  Cypress.on('log:added', onLogAdded)
+
+  const stopCollecting = () => {
+    Cypress.off('log:added', onLogAdded)
+  }
+
+  /** @param {Error} error */
+  const onFail = (error) => {
+    Cypress.off('fail', onFail)
+    stopCollecting()
+
+    throw error
+  }
+
+  Cypress.on('fail', onFail)
+
+  return cy.then(runCommand).then(() => {
+    Cypress.off('fail', onFail)
+    stopCollecting()
+
+    return messages
+  })
+}
+
+/** @param {string} message */
+const normalizeCdpMessage = (message) =>
+  message
+    .replace(/"nodeId":\d+/g, '"nodeId":<nodeId>')
+    .replace(/"backendNodeId":\d+/g, '"backendNodeId":<backendNodeId>')
+    .replace(/"objectId":"[^"]+"/g, '"objectId":"<objectId>"')
+
+it('should log internal CDP commands for getCDPNodeId by default', () => {
+  cy.visit('/public/index.html')
+
+  collectCdpMessages(() =>
+    cy.getCDPNodeId('body').should('be.a', 'number'),
+  ).then((messages) => {
+    cy.wrap(messages.map(normalizeCdpMessage)).should('deep.equal', [
+      'DOM.enable ',
+      'CSS.enable ',
+      'DOM.getDocument {"depth":50,"pierce":true}',
+      'DOM.querySelector iframe.aut-iframe',
+      'DOM.describeNode {"nodeId":<nodeId>}',
+      'DOM.resolveNode {"backendNodeId":<backendNodeId>}',
+      'DOM.requestNode {"objectId":"<objectId>"}',
+      'DOM.querySelector body',
+    ])
+  })
+})
+
+it('should suppress internal CDP logs for getCDPNodeId', () => {
+  cy.visit('/public/index.html')
+
+  collectCdpMessages(() =>
+    cy.getCDPNodeId('body', { log: false }).should('be.a', 'number'),
+  ).then((messages) => {
+    cy.wrap(messages).should('deep.equal', [])
+  })
+})

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -35,7 +35,13 @@ declare global {
       //#endregion
 
       //#region getCDPNodeId
-      type getCDPNodeIdFn = (selector: string) => Chainable<number>
+      interface getCDPNodeIdFnOptions {
+        log?: boolean
+      }
+      type getCDPNodeIdFn = (
+        selector: string,
+        options?: getCDPNodeIdFnOptions,
+      ) => Chainable<number>
       //#endregion
 
       //#region hasEventListeners

--- a/src/index.js
+++ b/src/index.js
@@ -143,31 +143,33 @@ Cypress.Commands.add('hasEventListeners', (selector, options = {}) => {
     })
 })
 
-Cypress.Commands.add('getCDPNodeId', (selector) => {
-  cy.CDP('DOM.enable')
-  cy.CDP('CSS.enable')
+Cypress.Commands.add('getCDPNodeId', (selector, options) => {
+  const cdpOptions = options?.log === false ? { log: false } : undefined
+
+  cy.CDP('DOM.enable', undefined, cdpOptions)
+  cy.CDP('CSS.enable', undefined, cdpOptions)
   cy.CDP('DOM.getDocument', {
     depth: 50,
     pierce: true,
-  }).then((doc) => {
+  }, cdpOptions).then((doc) => {
     // let's get the application iframe
     cy.CDP('DOM.querySelector', {
       nodeId: doc.root.nodeId,
       selector: 'iframe.aut-iframe',
-    }).then((iframeQueryResult) => {
+    }, cdpOptions).then((iframeQueryResult) => {
       cy.CDP('DOM.describeNode', {
         nodeId: iframeQueryResult.nodeId,
-      }).then((iframeDescription) => {
+      }, cdpOptions).then((iframeDescription) => {
         cy.CDP('DOM.resolveNode', {
           backendNodeId: iframeDescription.node.contentDocument.backendNodeId,
-        }).then((contentDocRemoteObject) => {
+        }, cdpOptions).then((contentDocRemoteObject) => {
           cy.CDP('DOM.requestNode', {
             objectId: contentDocRemoteObject.object.objectId,
-          }).then((contentDocNode) => {
+          }, cdpOptions).then((contentDocNode) => {
             cy.CDP('DOM.querySelector', {
               nodeId: contentDocNode.nodeId,
               selector,
-            }).its('nodeId')
+            }, cdpOptions).its('nodeId')
           })
         })
       })


### PR DESCRIPTION
Changes:

- Added `{ log: false }` support to `getCDPNodeId`.
- Added test coverage for default and suppressed CDP logging.
- Updated docs for the new logging option in the `getCDPNodeId` command.

Closes https://github.com/bahmutov/cypress-cdp/issues/98